### PR TITLE
prompt: display context if one is present

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,8 @@ New commands in tasksh 1.3.0
 
 New configuration options in tasksh 1.3.0
 
-  - 
+  - tasksh.contextprompt can be set to on/off to display taskwarrior's context
+    in tasksh's prompt.
 
 Known Issues
 

--- a/doc/man/tasksh.1.in
+++ b/doc/man/tasksh.1.in
@@ -144,6 +144,10 @@ in the Taskwarrior .taskrc file.
 If set to "1", causes each tasksh command to be preceded by a 'clear screen' and
 cursor reset. Default is "0".
 
+.TP
+.B tasksh.contextprompt=1
+If set to "1", will display the context (if set) in the prompt. Default is "0".
+
 .SH "CREDITS & COPYRIGHTS"
 Copyright (C) 2006 \- 2018 P. Beckingham, F. Hernandez.
 

--- a/src/prompt.cpp
+++ b/src/prompt.cpp
@@ -28,6 +28,8 @@
 #include <vector>
 #include <string>
 #include <Color.h>
+#include <Lexer.h>
+#include <shared.h>
 
 static std::vector <std::string> contextColors = {
   "bold white on red",
@@ -93,11 +95,36 @@ std::string promptCompose ()
   // TODO - The accumulated context, as colored tokens.
   // TODO - sync status
   // TODO - time
+  std::string prompt = "tasksh";
   auto decoration = composeContexts (true);
   if (decoration.length ())
     return "task " + decoration + "> ";
 
-  return "tasksh> ";
+  std::string dummy;;
+  std::string output;
+
+  bool hideContextPrompt = false;
+  execute ("task", {"_get", "rc.tasksh.contextprompt"}, dummy, output);
+  output = lowerCase (output);
+
+  hideContextPrompt = (output == "no\n"   ||
+		       output == "n\n"     ||
+		       output == "false\n" ||
+		       output == "0\n"     ||
+		       output == "off\n");
+
+  if (!hideContextPrompt)
+  {
+    execute ("task", {"_get", "rc.context"}, dummy, output);
+    output = Lexer::trimRight (output, "\n");
+
+    if (output != "")
+      prompt += " (" + output + ")";
+  }
+
+  prompt += "> ";
+
+  return prompt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The documentation for tasksh currently says that the tasksh prompt will
display the context if there is one.  This adds the context to the
prompt.

I'm curious though about expanding this out over time, to have placeholders for text, and other attributes from taskwarrior. Are there any preferences on how this might work or look?

Thanks!