### PR TITLE
[TS-30] implement a filter for the review command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ Thank you for taking a look at tasksh!!
 ---
 
 Tasksh is released under the MIT license. For details check the LICENSE file.
+
+# Important note
+When cloning this from the repo to build from source make sure you `git clone --recursive` to get all required submodules.

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -32,12 +32,12 @@ int cmdHelp ()
 {
   std::cout << '\n'
             << "  Commands:\n"
-            << "    tasksh> list             Or any other Taskwarrior command\n"
-            << "    tasksh> review [N]       Task review session, with optional cutoff after N tasks\n"
-            << "    tasksh> exec ls -al      Any shell command.  May also use '!ls -al'\n"
-            << "    tasksh> help             Tasksh help\n"
-            << "    tasksh> diagnostics      Tasksh diagnostics\n"
-            << "    tasksh> quit             End of session. May also use 'exit'\n"
+            << "    tasksh> list                    Or any other Taskwarrior command\n"
+            << "    tasksh> review [FILTER] [N]     Task review session, with optional filter and cutoff after N tasks\n"
+            << "    tasksh> exec ls -al             Any shell command.  May also use '!ls -al'\n"
+            << "    tasksh> help                    Tasksh help\n"
+            << "    tasksh> diagnostics             Tasksh diagnostics\n"
+            << "    tasksh> quit                    End of session. May also use 'exit'\n"
             << '\n'
             << "Run 'man tasksh' from your shell prompt.\n"
             << "Run '! man tasksh' from inside tasksh.\n"

--- a/src/review.cpp
+++ b/src/review.cpp
@@ -32,6 +32,8 @@
 #include <algorithm>
 #include <stdlib.h>
 
+#include <iterator>
+
 #ifdef HAVE_READLINE
 #include <readline/readline.h>
 #include <readline/history.h>
@@ -266,16 +268,12 @@ static void reviewLoop (const std::vector <std::string>& uuids, unsigned int lim
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-int cmdReview (const std::vector <std::string>& args, bool autoClear)
+static void configureReport()
 {
-  // Is there a specified limit?
-  unsigned int limit = 0;
-  if (args.size () == 2)
-    limit = strtol (args[1].c_str (), NULL, 10);
-
   // Configure 'reviewed' UDA, but only if necessary.
   std::string input;
   std::string output;
+
   auto status = execute ("task", {"_get", "rc.uda.reviewed.type"}, input, output);
   if (status || output != "date\n")
   {
@@ -300,21 +298,62 @@ int cmdReview (const std::vector <std::string>& args, bool autoClear)
                         "( reviewed.none: or reviewed.before:now-6days ) and ( +PENDING or +WAITING )"                         }, input, output);
     }
   }
+}
 
-  // Obtain a list of UUIDs to review.
-  status = execute ("task",
-                    {
-                      "rc.color=off",
-                      "rc.detection=off",
-                      "rc._forcecolor=off",
-                      "rc.verbose=nothing",
-                      "_reviewed"
-                    },
-                    input, output);
+////////////////////////////////////////////////////////////////////////////////
+int cmdReview (const std::vector <std::string>& args, bool autoClear)
+{
+  // Is there a specified limit?
+  //unsigned int limit = 0;
+  unsigned int limit = std::numeric_limits<unsigned int>::max();
+  int status = 0;
+  bool with_filter = false;
+  std::string input;
+  std::string output;
+  std::vector<std::string> filter;   // here we store our filter arguments
 
-  // Review the set of UUIDs.
-  auto uuids = split (Lexer::trimRight (output, "\n"), '\n');
-  reviewLoop (uuids, limit, autoClear);
+  //if (args.size () == 2)
+    //limit = strtol (args[1].c_str (), NULL, 10);
+  if (args.size () > 1)
+  {
+      with_filter = true;
+      auto begin = args.begin();
+      std::advance(begin, 1);
+      std::copy(begin, args.end(), std::back_inserter(filter));
+      //TODO: maybe also add "status:pending" ?
+      filter.push_back("uuids");
+  }
+
+  configureReport ();
+
+  if (with_filter)
+  {
+    // Obtain list of UUIDs to review, when a filter is given
+    status = execute ("task",
+                        filter,
+                        input, output);
+    // Review the set of UUIDs.
+    auto uuids = split (Lexer::trimRight (output, "\n"), ' ');
+    reviewLoop (uuids, limit, autoClear);
+  }
+  else
+  {
+    // Obtain a list of UUIDs to review.
+    status = execute ("task",
+                        {
+                        "rc.color=off",
+                        "rc.detection=off",
+                        "rc._forcecolor=off",
+                        "rc.verbose=nothing",
+                        "_reviewed"
+                        },
+                        input, output);
+
+    // Review the set of UUIDs.
+    auto uuids = split (Lexer::trimRight (output, "\n"), '\n');
+    reviewLoop (uuids, limit, autoClear);
+  }
+
   return 0;
 }
 

--- a/src/review.cpp
+++ b/src/review.cpp
@@ -32,8 +32,6 @@
 #include <algorithm>
 #include <stdlib.h>
 
-#include <iterator>
-
 #ifdef HAVE_READLINE
 #include <readline/readline.h>
 #include <readline/history.h>
@@ -301,7 +299,7 @@ static void configureReport()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-static bool is_number (const std::string& s)
+static bool isNumber (const std::string& s)
 {
     return !s.empty () && std::find_if(s.begin (),
             s.end (), [] (char c) { return !std::isdigit (c); }) == s.end ();
@@ -322,7 +320,7 @@ int cmdReview (const std::vector <std::string>& args, bool autoClear)
   {
     auto begin = args.begin ();
     auto end = args.end ();
-    if (is_number (args.back ())) // if last argument is numeric, treat it as limit.
+    if (isNumber (args.back ())) // if last argument is numeric, treat it as limit.
     {
       limit = strtol (args.back ().c_str (), NULL, 10);
       std::advance(end, -1);
@@ -332,7 +330,6 @@ int cmdReview (const std::vector <std::string>& args, bool autoClear)
     {
       with_filter = true;
       std::copy (begin, end, std::back_inserter (filter));
-      //TODO: maybe also add "status:pending" ?
       filter.emplace_back ("uuids");
     }
   }


### PR DESCRIPTION
Hi,

I've implemented a filter for the review command as requested in issue #29 with the following syntax:
`tasksh> review [filter] [N]`
Where filter can be any filter.
If a filter is used the default `_reviewed` UDA will not be used.
If no filter is provided the behavior is as before.
This is useful since you don't need to change your rc-file everytime you want to review a specific subset of your tasks.

Example queries:
```
tasksh> review +inbox
tasksh> review pro:myproject status:pending
```