### PR TITLE
The libshared submodule URL is not on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ Thank you for taking a look at tasksh!!
 ---
 
 Tasksh is released under the MIT license. For details check the LICENSE file.
+
+# Important note
+When cloning this from the repo to build from source make sure you `git clone --recursive` to get all required submodules.


### PR DESCRIPTION
The .gitmodules file is pointing to https://git.tasktools.org/TM/libshared.git, which if you try to clone will fail.  The URL needs changed to the github URL of https://github.com/GothenburgBitFactory/libshared.git