### PR TITLE
configuration option to not show help in welcome

### DIFF
--- a/doc/man/tasksh.1.in
+++ b/doc/man/tasksh.1.in
@@ -143,6 +143,11 @@ The review command storeѕ a UDA ('reviewed') and report definition ('_reviewed'
 If set to "1", causes each tasksh command to be preceded by a 'clear screen' and
 cursor reset. Default is "0".
 
+.TP
+.B tasksh.nohelp=1
+If set to "1", tasksh will not show the output of the 'help' command as part of
+its welcome message. Default is "0".
+
 .SH "CREDITS & COPYRIGHTS"
 Copyright (C) 2006 \- 2017 P. Beckingham, F. Hernandez.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,10 +52,11 @@ std::string promptCompose ();
 std::string findTaskwarrior ();
 
 ////////////////////////////////////////////////////////////////////////////////
-static void welcome ()
+static void welcome (bool noHelp)
 {
   std::cout << PACKAGE_STRING << "\n";
-  cmdHelp ();
+  if (! noHelp)
+    cmdHelp ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -139,6 +140,20 @@ static int commandLoop (bool autoClear)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+static bool getBoolFromTaskrc (const std::string& path)
+{
+  std::string input;
+  std::string output;
+  execute ("task", {"_get", path}, input, output);
+  output = lowerCase (output);
+  return output == "true\n" ||
+         output == "1\n"    ||
+         output == "y\n"    ||
+         output == "yes\n"  ||
+         output == "on\n"   ;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 int main (int argc, const char** argv)
 {
   int status = 0;
@@ -153,19 +168,11 @@ int main (int argc, const char** argv)
     try
     {
       // Get the Taskwarrior rc.tasksh.autoclear Boolean setting.
-      bool autoClear = false;
-      std::string input;
-      std::string output;
-      execute ("task", {"_get", "rc.tasksh.autoclear"}, input, output);
-      output = lowerCase (output);
-      autoClear = (output == "true\n" ||
-                   output == "1\n"    ||
-                   output == "y\n"    ||
-                   output == "yes\n"  ||
-                   output == "on\n");
+      bool autoClear = getBoolFromTaskrc("rc.tasksh.autoclear");
+      bool noHelp = getBoolFromTaskrc("rc.tasksh.nohelp");
 
       if (isatty (fileno (stdin)))
-        welcome ();
+        welcome (noHelp);
 
       while ((status = commandLoop (autoClear)) == 0)
         ;


### PR DESCRIPTION
This adds a taskrc option `tasksh.nohelp = 1` to hide the output of `help` as part of tasksh's welcome message.