### PR TITLE
updated url for libshared submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/libshared"]
 	path = src/libshared
-	url = https://git.tasktools.org/TM/libshared.git
+	url = https://github.com/GothenburgBitFactory/libshared


### PR DESCRIPTION
don't forget to `git submodule sync`

The current submodule url has a SSL certificate problem...