### PR TITLE
Add Installation Instructions for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Installing
+* Debian/Ubuntu:
+```
+$ sudo apt-get install tasksh
+```
+
 # Disclaimer during ongoing development
 
 The development branch is a work in progress and may not pass all quality tests,


### PR DESCRIPTION
I spent quite some time trying to compile taskshell from source since I could not find `taskshell` with apt. Adding Installation Instructions might save other people time.